### PR TITLE
ssh: use POSIX shell /bin/sh to copy files

### DIFF
--- a/pkg/cluster/run.go
+++ b/pkg/cluster/run.go
@@ -38,7 +38,7 @@ func containerRun(nameOrID string, name string, args ...string) error {
 }
 
 func containerRunShell(nameOrID string, script string) error {
-	return containerRun(nameOrID, "/bin/bash", "-c", script)
+	return containerRun(nameOrID, "/bin/sh", "-c", script)
 }
 
 func copy(nameOrID string, content []byte, path string) error {


### PR DESCRIPTION
Some tiny distros like Alpine, does not include bash by default. Use /bin/sh which is specified by POSIX.

https://pubs.opengroup.org/onlinepubs/9699919799/utilities/sh.html