### PR TITLE
Make machine IDs unique on Debian 10

### DIFF
--- a/images/debian10/Dockerfile
+++ b/images/debian10/Dockerfile
@@ -17,6 +17,10 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+# Truncate machine ID files to trigger regeneration.
+RUN >/etc/machine-id
+RUN >/var/lib/dbus/machine-id
+
 EXPOSE 22
 
 RUN systemctl set-default multi-user.target


### PR DESCRIPTION
My left-open PR 282 from old repo recreated

Clears the machine ID files to force regeneration on Debian 10. Previously the image had a pre-set constant machine ID on all instances which didn't make kube happy on multi node clusters.

Commands replicated from Dockerfiles for other images, such as https://github.com/k0sproject/footloose/blob/main/images/ubuntu20.04/Dockerfile#L20-L21


