### PR TITLE
Rename container labels to io.k0sproject.footloose

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -286,8 +286,8 @@ func (c *Cluster) CreateMachine(machine *Machine, i int) error {
 func (c *Cluster) createMachineRunArgs(machine *Machine, name string, i int) []string {
 	runArgs := []string{
 		"-it",
-		"--label", "works.weave.owner=footloose",
-		"--label", "works.weave.cluster=" + c.spec.Cluster.Name,
+		"--label", "io.k0sproject.footloose.owner=footloose",
+		"--label", "io.k0sproject.footloose.cluster=" + c.spec.Cluster.Name,
 		"--name", name,
 		"--hostname", machine.Hostname(),
 		"--tmpfs", "/run",

--- a/tests/test-create-delete-%image.cmd
+++ b/tests/test-create-delete-%image.cmd
@@ -1,5 +1,5 @@
 footloose config create --override --config %testName.footloose --name %testName --key %testName-key --image quay.io/footloose/%image
 footloose create --config %testName.footloose
-%out docker ps --format {{.Names}} -f label=works.weave.cluster=%testName
+%out docker ps --format {{.Names}} -f label=io.k0sproject.footloose.cluster=%testName
 footloose delete --config %testName.footloose
-%out docker ps --format {{.Names}} -f label=works.weave.cluster=%testName
+%out docker ps --format {{.Names}} -f label=io.k0sproject.footloose.cluster=%testName

--- a/tests/test-create-delete-persistent-%image.cmd
+++ b/tests/test-create-delete-persistent-%image.cmd
@@ -1,6 +1,6 @@
 footloose config create --override --config %testName.footloose --name %testName --key %testName-key --image quay.io/footloose/%image
 footloose create --config %testName.footloose
-%out docker ps --format {{.Names}} -f label=works.weave.cluster=%testName
+%out docker ps --format {{.Names}} -f label=io.k0sproject.footloose.cluster=%testName
 %out docker inspect %testName-node0 -f "{{.HostConfig.AutoRemove}}"
 footloose delete --config %testName.footloose
-%out docker ps --format {{.Names}} -f label=works.weave.cluster=%testName
+%out docker ps --format {{.Names}} -f label=io.k0sproject.footloose.cluster=%testName

--- a/tests/test-create-stop-start-%image.cmd
+++ b/tests/test-create-stop-start-%image.cmd
@@ -1,6 +1,6 @@
 footloose config create --override --config %testName.footloose --name %testName --key %testName-key --image quay.io/footloose/%image
 footloose create --config %testName.footloose
-%out docker ps --format {{.Names}} -f label=works.weave.cluster=%testName
+%out docker ps --format {{.Names}} -f label=io.k0sproject.footloose.cluster=%testName
 footloose stop --config %testName.footloose
 %out docker inspect %testName-node0 -f "{{.State.Running}}"
 footloose start --config %testName.footloose


### PR DESCRIPTION
Replaces the labels as suggested in https://docs.docker.com/config/labels-custom-metadata/#key-format-recommendations

