### PR TITLE
Fix pkg/exec import to point to k0sproject/footloose

### DIFF
--- a/pkg/docker/info.go
+++ b/pkg/docker/info.go
@@ -19,7 +19,7 @@ package docker
 import (
 	"fmt"
 
-	"github.com/weaveworks/footloose/pkg/exec"
+	"github.com/k0sproject/footloose/pkg/exec"
 )
 
 // Info return system-wide information


### PR DESCRIPTION
Not sure why this doesn't affect go.mod/go.sum 🤔 
