### PR TITLE
Drop deprecated ioutil

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -3,7 +3,6 @@ package cluster
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -13,14 +12,14 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/ghodss/yaml"
-	"github.com/mitchellh/go-homedir"
-	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
 	"github.com/k0sproject/footloose/pkg/config"
+	"github.com/k0sprojecs/footloose/pkg/config"
 	"github.com/k0sproject/footloose/pkg/docker"
 	"github.com/k0sproject/footloose/pkg/exec"
 	"github.com/k0sproject/footloose/pkg/ignite"
-)
+	"github.com/mitchellh/go-homedir"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus
 
 // Container represents a running machine.
 type Container struct {
@@ -57,7 +56,7 @@ func NewFromYAML(data []byte) (*Cluster, error) {
 // NewFromFile creates a new Cluster from a YAML serialization of its
 // configuration available in the provided file.
 func NewFromFile(path string) (*Cluster, error) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +80,7 @@ func (c *Cluster) Save(path string) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(path, data, 0666)
+	return os.WriteFile(path, data, 0666)
 }
 
 func f(format string, args ...interface{}) string {
@@ -205,7 +204,7 @@ func (c *Cluster) publicKey(machine *Machine) ([]byte, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "public key expand")
 	}
-	return ioutil.ReadFile(path + ".pub")
+	return os.ReadFile(path + ".pub")
 }
 
 // CreateMachine creates and starts a new machine in the cluster.
@@ -598,11 +597,15 @@ func (f *matchFilter) Write(p []byte) (n int, err error) {
 }
 
 // Matches:
-//   ssh_exchange_identification: read: Connection reset by peer
+//
+//
+//	h_exchange_identification: read: Connection reset by peer
 var connectRefused = regexp.MustCompile("^ssh_exchange_identification: ")
 
 // Matches:
-//   Warning:Permanently added '172.17.0.2' (ECDSA) to the list of known hosts
+//
+//	
+//	Warning:Permanently added '172.17.0.2' (ECDSA) to the list of known hosts
 var knownHosts = regexp.MustCompile("^Warning: Permanently added .* to the list of known hosts.")
 
 // ssh returns true if the command should be tried again.

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -1,7 +1,7 @@
 package cluster
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,7 +11,7 @@ func TestMatchFilter(t *testing.T) {
 	const refused = "ssh: connect to host 172.17.0.2 port 22: Connection refused"
 
 	filter := matchFilter{
-		writer: ioutil.Discard,
+		writer: io.Discard,
 		regexp: connectRefused,
 	}
 

--- a/pkg/cluster/key_store.go
+++ b/pkg/cluster/key_store.go
@@ -1,7 +1,6 @@
 package cluster
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -46,7 +45,7 @@ func (s *KeyStore) Store(name, key string) error {
 		return errors.Errorf("key store: store: key '%s' already exists", name)
 	}
 
-	if err := ioutil.WriteFile(s.keyPath(name), []byte(key), 0644); err != nil {
+	if err := os.WriteFile(s.keyPath(name), []byte(key), 0644); err != nil {
 		return errors.Wrap(err, "key store: write")
 	}
 
@@ -58,7 +57,7 @@ func (s *KeyStore) Get(name string) ([]byte, error) {
 	if !s.keyExists(name) {
 		return nil, errors.Errorf("key store: get: unknown key '%s'", name)
 	}
-	return ioutil.ReadFile(s.keyPath(name))
+	return os.ReadFile(s.keyPath(name))
 }
 
 // Remove removes a key from the store.

--- a/pkg/config/cluster.go
+++ b/pkg/config/cluster.go
@@ -2,7 +2,7 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
@@ -17,7 +17,7 @@ func NewConfigFromYAML(data []byte) (*Config, error) {
 }
 
 func NewConfigFromFile(path string) (*Config, error) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/docker/archive.go
+++ b/pkg/docker/archive.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/pkg/errors"
@@ -57,7 +56,7 @@ func GetArchiveTags(path string) ([]string, error) {
 		}
 	}
 	// read and parse the tags
-	b, err := ioutil.ReadAll(tr)
+	b, err := io.ReadAll(tr)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -266,14 +265,14 @@ func (t *test) run() (string, error) {
 
 func (t *test) goldenOutput() string {
 	// testname.golden.output takes precedence.
-	golden, err := ioutil.ReadFile(t.testname + ".golden.output")
+	golden, err := os.ReadFile(t.testname + ".golden.output")
 	if err == nil {
 		return string(golden)
 	}
 
 	// Expand a generic golden output.
 	baseFilename := t.file[:len(t.file)-len(".cmd")]
-	data, err := ioutil.ReadFile(baseFilename + ".golden.output")
+	data, err := os.ReadFile(baseFilename + ".golden.output")
 	if err != nil {
 		// not having any golden output isn't an error, it just means the test
 		// shouldn't output anything.
@@ -319,9 +318,9 @@ func runTest(t *testing.T, test *test) {
 
 	// 2. b) Compare file content.
 	for i := range goldenFiles {
-		golden, err := ioutil.ReadFile(goldenDir + goldenFiles[i])
+		golden, err := os.ReadFile(goldenDir + goldenFiles[i])
 		assert.NoError(t, err)
-		got, err := ioutil.ReadFile(gotDir + gotFiles[i])
+		got, err := os.ReadFile(gotDir + gotFiles[i])
 		assert.NoError(t, err)
 
 		assert.Equal(t, string(golden), string(got))
@@ -329,7 +328,7 @@ func runTest(t *testing.T, test *test) {
 }
 
 func loadVariables(t *testing.T) variables {
-	data, err := ioutil.ReadFile("variables.json")
+	data, err := os.ReadFile("variables.json")
 	if err != nil {
 		// it's allowed to not have any variable!
 		return nil


### PR DESCRIPTION
Replaces ioutil usages with the modern alternatives.

Includes some gofmt created import reordering on the modified files.

