### PR TITLE
Change "go get" to "go install" in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Build and install `footloose` from source. It requires having
 `go >= 1.11` installed:
 
 ```console
-go get github.com/k0sproject/footloose
+go install github.com/k0sproject/footloose/...@latest
 ```
 
 [gh-release]: https://github.com/k0sproject/footloose/releases


### PR DESCRIPTION
Readme had an old `go get` install example that doesn't work on modern go versions. 

TODO: This one doesn't work either since there is no `@latest`.
