### PR TITLE
Fix linting errors 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.7.0
 	github.com/stretchr/testify v1.7.0
+	golang.org/x/text v0.3.3
 	gopkg.in/yaml.v2 v2.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,7 @@ golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.11.0 h1:eG7RXZHdqOJ1i+0lgLgCpSXAp6M3LYlAo6osgSi0xOM=
 golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=

--- a/pkg/cluster/formatter.go
+++ b/pkg/cluster/formatter.go
@@ -88,7 +88,7 @@ type writer struct {
 }
 
 // writerColumns is a no-op if there was an error already
-func (wr writer) writeColumns(w io.Writer, cols []string) {
+func (wr *writer) writeColumns(w io.Writer, cols []string) {
 	if wr.err != nil {
 		return
 	}
@@ -99,7 +99,7 @@ func (wr writer) writeColumns(w io.Writer, cols []string) {
 // Format will output to stdout in table format.
 func (TableFormatter) Format(w io.Writer, machines []*Machine) error {
 	const padding = 3
-	wr := new(writer)
+	wr := &writer{}
 	var statuses []MachineStatus
 	for _, m := range machines {
 		statuses = append(statuses, *m.Status())

--- a/pkg/config/get.go
+++ b/pkg/config/get.go
@@ -5,6 +5,9 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 func pathSplit(r rune) bool {
@@ -15,18 +18,19 @@ func pathSplit(r rune) bool {
 func GetValueFromConfig(stringPath string, object interface{}) (interface{}, error) {
 	keyPath := strings.FieldsFunc(stringPath, pathSplit)
 	v := reflect.ValueOf(object)
+	caser := cases.Title(language.English)
 	for _, key := range keyPath {
-		keyUpper := strings.Title(key)
+		keyTitle := caser.String(key)
 		for v.Kind() == reflect.Ptr {
 			v = v.Elem()
 		}
 		if v.Kind() == reflect.Struct {
-			v = v.FieldByName(keyUpper)
+			v = v.FieldByName(keyTitle)
 			if !v.IsValid() {
-				return nil, fmt.Errorf("%v key does not exist", keyUpper)
+				return nil, fmt.Errorf("%v key does not exist", keyTitle)
 			}
 		} else if v.Kind() == reflect.Slice {
-			index, errConv := strconv.Atoi(keyUpper)
+			index, errConv := strconv.Atoi(keyTitle)
 			if errConv != nil {
 				return nil, fmt.Errorf("%v is not an index", key)
 			}

--- a/pkg/docker/info.go
+++ b/pkg/docker/info.go
@@ -17,8 +17,6 @@ limitations under the License.
 package docker
 
 import (
-	"fmt"
-
 	"github.com/k0sproject/footloose/pkg/exec"
 )
 
@@ -26,7 +24,7 @@ import (
 func Info(format string) ([]string, error) {
 	cmd := exec.Command("docker", "info",
 		"-f", // format
-		fmt.Sprintf("%s", format),
+		format,
 	)
 	return exec.CombinedOutputLines(cmd)
 }


### PR DESCRIPTION
- pkg/config/get.go:19:15: SA1019: strings.Title has been deprecated since Go 1.18 and an alternative has been available since Go 1.0: The rule Title uses for word boundaries does not handle Unicode punctuation properly. Use golang.org/x/text/cases instead. (staticcheck)
- pkg/docker/info.go:29:3: S1025: the argument is already a string, there's no need to use fmt.Sprintf (gosimple)
- pkg/cluster/formatter.go:96:2: SA4005: ineffective assignment to field writer.err (staticcheck)
