### PR TITLE
Bump fedora image from version 29 to 38

### DIFF
--- a/images/fedora38/Dockerfile
+++ b/images/fedora38/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:29
+FROM fedora:38
 
 ENV container docker
 

--- a/tests/variables.json
+++ b/tests/variables.json
@@ -2,7 +2,7 @@
   "image": [
     "amazonlinux2",
     "centos7",
-    "fedora29",
+    "fedora38",
     "ubuntu18.04",
     "ubuntu20.04",
     "debian10",


### PR DESCRIPTION
The Dockerfile is so spartan that I suspect it may not be fully footloosified.

