### PR TITLE
Cleanup of leftover files generated during e2e tests

### DIFF
--- a/tests/test-basic-commands-%image.cmd
+++ b/tests/test-basic-commands-%image.cmd
@@ -1,5 +1,6 @@
 # Test that common utilities are present in the base images
 footloose config create --config %testName.footloose --override --name %testName --key %testName-key --image %image
+%defer rm -f %testName.footloose %testName-key %testName-key.pub
 %defer footloose delete --config %testName.footloose
 footloose create --config %testName.footloose
 footloose --config %testName.footloose ssh root@node0 hostname

--- a/tests/test-config-get-ubuntu18.04.cmd
+++ b/tests/test-config-get-ubuntu18.04.cmd
@@ -1,2 +1,3 @@
 footloose config create --override --config %testName.footloose --name %testName --key %testName-key --networks=net1,net2 --image %image
+%defer rm -f %testName.footloose %testName-key %testName-key.pub
 %out footloose config get --config %testName.footloose machines[0].spec

--- a/tests/test-create-config-already-exists-%image.cmd
+++ b/tests/test-create-config-already-exists-%image.cmd
@@ -1,2 +1,3 @@
 footloose config create --config %testName.footloose --name %testName --key %testName-key --image %image
+%defer rm -f %testName.footloose %testName-key %testName-key.pub
 footloose config create --config %testName.footloose --name %testName --key %testName-key --image %image

--- a/tests/test-create-delete-%image.cmd
+++ b/tests/test-create-delete-%image.cmd
@@ -1,4 +1,5 @@
 footloose config create --override --config %testName.footloose --name %testName --key %testName-key --image %image
+%defer rm -f %testName.footloose %testName-key %testName-key.pub
 %defer footloose delete --config %testName.footloose
 footloose create --config %testName.footloose
 %out docker ps --format {{.Names}} -f label=io.k0sproject.footloose.cluster=%testName

--- a/tests/test-create-delete-idempotent-%image.cmd
+++ b/tests/test-create-delete-idempotent-%image.cmd
@@ -1,4 +1,5 @@
 footloose config create --override --config %testName.footloose --name %testName --key %testName-key --image %image
+%defer rm -f %testName.footloose %testName-key %testName-key.pub
 %defer footloose delete --config %testName.footloose
 footloose create --config %testName.footloose
 footloose create --config %testName.footloose

--- a/tests/test-create-delete-persistent-%image.cmd
+++ b/tests/test-create-delete-persistent-%image.cmd
@@ -1,4 +1,5 @@
 footloose config create --override --config %testName.footloose --name %testName --key %testName-key --image %image
+%defer rm -f %testName.footloose %testName-key %testName-key.pub
 %defer footloose delete --config %testName.footloose
 footloose create --config %testName.footloose
 %out docker ps --format {{.Names}} -f label=io.k0sproject.footloose.cluster=%testName

--- a/tests/test-create-stop-start-%image.cmd
+++ b/tests/test-create-stop-start-%image.cmd
@@ -1,4 +1,5 @@
 footloose config create --override --config %testName.footloose --name %testName --key %testName-key --image %image
+%defer rm -f %testName.footloose %testName-key %testName-key.pub
 %defer footloose delete --config %testName.footloose
 footloose create --config %testName.footloose
 %out docker ps --format {{.Names}} -f label=io.k0sproject.footloose.cluster=%testName

--- a/tests/test-show-ubuntu18.04.cmd
+++ b/tests/test-show-ubuntu18.04.cmd
@@ -1,4 +1,5 @@
 footloose config create --override --config %testName.footloose --name %testName --key %testName-key --image ubuntu18.04
+%defer rm -f %testName.footloose %testName-key %testName-key.pub
 %defer footloose delete --config %testName.footloose
 footloose create --config %testName.footloose
 footloose delete --config %testName.footloose

--- a/tests/test-ssh-remote-command-%image.cmd
+++ b/tests/test-ssh-remote-command-%image.cmd
@@ -1,4 +1,5 @@
 footloose config create --override --config %testName.footloose --name %testName --key %testName-key --image %image
+%defer rm -f %testName.footloose %testName-key %testName-key.pub
 %defer footloose delete --config %testName.footloose
 footloose create --config %testName.footloose
 %out footloose --config %testName.footloose ssh root@node0 hostname

--- a/tests/test-ssh-user-%image.cmd
+++ b/tests/test-ssh-user-%image.cmd
@@ -1,4 +1,5 @@
 footloose config create --override --config %testName.footloose --name %testName --key %testName-key --image %image
+%defer rm -f %testName.footloose %testName-key %testName-key.pub
 %defer footloose delete --config %testName.footloose
 footloose create --config %testName.footloose
 footloose show --config %testName.footloose

--- a/tests/test-start-stop-specific-%image.cmd
+++ b/tests/test-start-stop-specific-%image.cmd
@@ -1,4 +1,5 @@
 footloose config create --override --config %testName.footloose --name %testName --key %testName-key --image %image --replicas 3
+%defer rm -f %testName.footloose %testName-key %testName-key.pub
 %defer footloose delete --config %testName.footloose
 footloose create --config %testName.footloose
 footloose stop %testName-node1 --config %testName.footloose


### PR DESCRIPTION
The e2e tests generate config and key files that are left behind when the tests finish, cluttering the tests/ dir with untracked files.

