### PR TITLE
Replace "footloose" with "go run ...." in e2e tests

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -81,9 +81,6 @@ jobs:
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
     
-    - name: Run go install
-      run: go install
-
     - name: Remove any leftover footloose machines
       run: docker ps -a --filter "label=io.k0sproject.footloose.owner=footloose" --format "{{.ID}}" | xargs -r docker rm
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -6,11 +6,8 @@ test-all: $(STAMPS) install
 	@go test ./ -args -image=$($(MAKE) -C ../images list IFS=,)
 
 # Test individual images
-test-%: ../images/.stamp-% install
+test-%: ../images/.stamp-%
 	@go test -v -args -image=$* ./...
 
-install:
-	$(MAKE) -C .. install
-
 # Phony targets
-.PHONY: test-all list test-% install
+.PHONY: test-all list test-%

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -231,15 +231,20 @@ func (t *test) parseCmd(line string) cmd {
 	}
 
 	cmd := cmd{}
-	switch parts[0] {
-	case "%out":
-		cmd.captureOutput = true
-		parts = parts[1:]
-	case "%defer":
-		cmd.doDefer = true
-		parts = parts[1:]
-	case "footloose":
-		parts = append(goRun, parts[1:]...)
+	var done bool
+	for !done {
+		switch parts[0] {
+		case "%out":
+			cmd.captureOutput = true
+			parts = parts[1:]
+		case "%defer":
+			cmd.doDefer = true
+			parts = parts[1:]
+		case "footloose":
+			parts = append(goRun, parts[1:]...)
+		default:
+		  done = true
+		}
 	}
 
 	cmd.name = parts[0]

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"testing"
@@ -203,6 +204,12 @@ func (t *test) image() string {
 	return parts[len(parts)-1]
 }
 
+// returns the path to to project root (assuming this file is still in the tests/ directory)
+func appPath() string {
+	_, self, _, _ := runtime.Caller(0)
+	return filepath.Dir(filepath.Dir(self))
+}
+
 func (t *test) expandVars(s string) string {
 	replacements := copyArray(t.vars)
 	replacements = append(replacements,
@@ -216,6 +223,7 @@ func (t *test) expandVars(s string) string {
 
 func (t *test) parseCmd(line string) cmd {
 	parts := strings.Split(line, " ")
+	goRun := []string{"go", "run", appPath() + "/."}
 
 	// Replace special strings
 	for i := range parts {
@@ -230,6 +238,8 @@ func (t *test) parseCmd(line string) cmd {
 	case "%defer":
 		cmd.doDefer = true
 		parts = parts[1:]
+	case "footloose":
+		parts = append(goRun, parts[1:]...)
 	}
 
 	cmd.name = parts[0]

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -231,8 +231,8 @@ func (t *test) parseCmd(line string) cmd {
 	}
 
 	cmd := cmd{}
-	var done bool
-	for !done {
+
+	replaceOuter: for {
 		switch parts[0] {
 		case "%out":
 			cmd.captureOutput = true
@@ -243,7 +243,7 @@ func (t *test) parseCmd(line string) cmd {
 		case "footloose":
 			parts = append(goRun, parts[1:]...)
 		default:
-		  done = true
+			break replaceOuter
 		}
 	}
 


### PR DESCRIPTION
Instead of requiring and using `footloose` in PATH, replaces the `footloose` commands encountered in e2e `.cmd` files with `go run <project_root>/.`. This allows modifying code and running tests without installing a development version into PATH.

