### PR TITLE
Fix tag fallback to latest when publishing images

### DIFF
--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -32,7 +32,7 @@ jobs:
           if [ -z "$TAG" ] && [[ "$GITHUB_REF" = refs/tags/* ]]; then
             TAG="${GITHUB_REF#refs/tags/}"
           fi
-          echo tag="${TAG-latest}" >>"$GITHUB_OUTPUT"
+          echo tag="${TAG:-latest}" >>"$GITHUB_OUTPUT"
 
       - name: List images
         id: list-images


### PR DESCRIPTION
Using the `-` operator when defaulting the image tag didn't work as intended. It only uses the provided value if the variable is unset. However, the variable was always set to the empty string whenever the fallback was desired, resulting in an empty tag being used when pushing the image, which then failed subsequently due to an invalid reference format.

Use the `:-` operator instead, which replaces both unset and empty variables.

Fixes:

* #75